### PR TITLE
fix: Fix first variant

### DIFF
--- a/contents/wrap-arrow-function-body-in-parentheses.md
+++ b/contents/wrap-arrow-function-body-in-parentheses.md
@@ -12,7 +12,7 @@ Looking at the two versions below, it is easy for the first variant to cause a m
 
 ```js
 // Bad
-const compareToZero = (a) => (a <= 0 ? 0 : a);
+const compareToZero = (a) => a <= 0 ? 0 : a;
 
 // Good
 const compareToZero = (a) => (a <= 0 ? 0 : a);


### PR DESCRIPTION
Hello! Great tips! 

On the [page](https://getfrontend.tips/wrap-arrow-function-body-in-parentheses/)  both variants contain the same code. 